### PR TITLE
Feat/1 return cohort to markdown

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ __pycache__
 
 _DS_Store
 
+test_outputs/
 outputs/
 datasets/
 logs/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ graphviz = "^0.20.3"
 [tool.poetry.scripts]
 test-gemini = "llm_source_to_kg.test.test_gemini:main"
 test-logger = "llm_source_to_kg.test.test_logger:main"
+test-cohort-graph = "llm_source_to_kg.graph.cohort_graph.orchestrator:main"
 
 [tool.poetry.group.dev.dependencies]
 ipykernel = "^6.29.5"

--- a/src/llm_source_to_kg/graph/cohort_graph/nodes/load_source_content.py
+++ b/src/llm_source_to_kg/graph/cohort_graph/nodes/load_source_content.py
@@ -4,7 +4,7 @@ from llm_source_to_kg.config import config
 from llm_source_to_kg.graph.cohort_graph.state import CohortGraphState
 import json
 
-def load_source_content(state: CohortGraphState, source_id: str) -> CohortGraphState:
+def load_source_content(state: CohortGraphState) -> CohortGraphState:
     """
     소스 콘텐츠를 로드하고 state를 업데이트합니다.
     
@@ -15,6 +15,8 @@ def load_source_content(state: CohortGraphState, source_id: str) -> CohortGraphS
     Returns:
         업데이트된 state
     """
+    source_id = state["source_reference_number"]
+    
     logger = get_logger()
     logger.info(f"Loading source content: {source_id}")
     
@@ -39,13 +41,13 @@ if __name__ == "__main__":
         "answer": "",
         "is_valid": False,
         "retries": 0,
-        "source_reference_number": "",
+        "source_reference_number": "NG238",
         "source_contents": "",
         "cohort_result": []
     }
     
     # 함수 테스트
-    updated_state = load_source_content(test_state, "NG238")
+    updated_state = load_source_content(test_state)
     print(updated_state['source_contents'])
     print(f"Source Reference Number: {updated_state['source_reference_number']}")
     print(f"Source Contents Length: {len(updated_state['source_contents'])}")

--- a/src/llm_source_to_kg/graph/cohort_graph/nodes/return_final_cohorts.py
+++ b/src/llm_source_to_kg/graph/cohort_graph/nodes/return_final_cohorts.py
@@ -1,5 +1,71 @@
 from llm_source_to_kg.graph.cohort_graph.state import CohortGraphState
+from typing import List, Dict, Any
+
+
+def cohort_to_markdown(cohort: Dict[str, Any]) -> str:
+    """
+    코호트 데이터를 마크다운 형식으로 변환합니다.
+    
+    Args:
+        cohort: 변환할 코호트 데이터
+        
+    Returns:
+        마크다운 형식의 문자열
+    """
+    markdown = f"# Cohort: {cohort['subject']}\n"
+    
+    if 'details' in cohort and cohort['details']:
+        markdown += f"{cohort['details']}\n\n"
+    
+    for i, sub_cohort in enumerate(cohort.get('sub_cohorts', []), 1):
+        description = sub_cohort.get('description', {})
+        subject = description.get('subject', '')
+        details = description.get('details', '')
+        
+        markdown += f"## {i}. {subject}\n"
+        if details:
+            markdown += f"{details}\n\n"
+        
+        inclusion_criteria = sub_cohort.get('inclusion_criteria', [])
+        if inclusion_criteria:
+            markdown += "### Inclusion Criteria\n"
+            for criterion in inclusion_criteria:
+                markdown += f"- {criterion}\n"
+            markdown += "\n"
+        
+        exclusion_criteria = sub_cohort.get('exclusion_criteria', [])
+        if exclusion_criteria:
+            markdown += "### Exclusion Criteria\n"
+            for criterion in exclusion_criteria:
+                markdown += f"- {criterion}\n"
+            markdown += "\n"
+        
+        source_sentences = sub_cohort.get('source_sentences', [])
+        if source_sentences:
+            markdown += "### Reference Sentences\n"
+            for sentence in source_sentences:
+                markdown += f"- {sentence}\n"
+            markdown += "\n"
+    
+    return markdown
+
 
 def return_final_cohorts(state: CohortGraphState) -> CohortGraphState:
+    """
+    코호트 결과를 마크다운 형식으로 변환하여 상태에 저장합니다.
+    
+    Args:
+        state: 그래프 상태
+        
+    Returns:
+        업데이트된 그래프 상태
+    """
+    cohorts_json = state['cohorts_json']
+    main_cohorts = cohorts_json.get('main_cohorts', [])
+    
+    markdown_cohorts = [cohort_to_markdown(cohort) for cohort in main_cohorts]
+    
+    state['cohorts_markdown'] = markdown_cohorts
+    
     return state
 

--- a/src/llm_source_to_kg/graph/cohort_graph/state.py
+++ b/src/llm_source_to_kg/graph/cohort_graph/state.py
@@ -11,4 +11,5 @@ class CohortGraphState(TypedDict):
     retries: Annotated[int, 'retry count']
     source_reference_number: Annotated[str, 'NICE Guideline referece Number']
     source_contents: Annotated[str, 'NICE Guideline contents']
-    cohort_result: Annotated[List[Dict[str, Any]], 'cohort Result']
+    cohorts_json: Annotated[List[Dict[str, Any]], 'cohort Result']
+    cohorts_markdown: Annotated[List[str], 'cohort Result in markdown']


### PR DESCRIPTION
# 🔄 변경 사항
<!-- 주요 변경 사항을 설명해주세요 -->
cohort_graph에서 넘기는 최종 코호트 마크다운 형식으로 변경

## 작업 내용
<!-- 어떤 내용을 변경했는지 설명해주세요 -->
- cohort_graph에서 넘기는 최종 코호트 마크다운 형식으로 변경
- extract_cohort에서 추출한 코호트, 파이썬 객체로 변환하는 과정 추가
- poetry script를 통해 cohort_graph 테스트 가능하도록 추가

## 관련 이슈
<!-- 관련된 이슈 번호를 작성해주세요 (예: #123) -->
#1 
# 📝 체크리스트
<!-- PR 전 확인해야 할 사항들을 체크해주세요 -->
- [x] main 브랜치와 충돌 여부 확인
- [x] 테스트 충분히 했는지 확인

# 📌 추가 정보
<!-- 추가로 필요한 정보가 있다면 작성해주세요 --> 

@rose2gyqls 
가이드라인 문서들은 전부 [S3](https://ap-northeast-2.console.aws.amazon.com/s3/buckets/source-to-kg?region=ap-northeast-2&bucketType=general&prefix=nice/&showversions=false)에 있음. [AWS 프로필 설정 노션](https://www.notion.so/AWS-Profile-1fa12a5f4e5d8008aff2e1d76711be33?pvs=4) 참고
```python
from llm_source_to_kg.utils.s3 import get_file_content_from_s3
from llm_source_to_kg.config import config

source_content_json = get_file_content_from_s3(config.AWS_S3_BUCKET, f"nice/{source_id}.json")
```

이렇게 불러올 수 있는데, 문서 불러오는 코드 쪽에는 다 반영 되어 있으니까 문서 번호 바꿔가면서 테스트 하면 될 듯

---
@HyejiYu `poetry run test-cohort-graph` 하면 test_outputs 디렉터리에 결과 개별 .md 파일로 저장됨. 