### PR TITLE
[#11]Modify: 코호트 추출 criteria에 AND, OR 명시

### DIFF
--- a/src/llm_source_to_kg/graph/cohort_graph/nodes/return_final_cohorts.py
+++ b/src/llm_source_to_kg/graph/cohort_graph/nodes/return_final_cohorts.py
@@ -2,6 +2,41 @@ from llm_source_to_kg.graph.cohort_graph.state import CohortGraphState
 from typing import List, Dict, Any
 
 
+def format_criteria_to_markdown(criteria: List[List[str]]) -> str:
+    """
+    새로운 중첩 배열 구조의 criteria를 마크다운 형식으로 변환합니다.
+    
+    Args:
+        criteria: 변환할 criteria 배열 (배열의 배열 구조)
+                 예: [["diabetes", "age>=18"], ["prediabetes", "high_risk"]]
+                 의미: (diabetes AND age>=18) OR (prediabetes AND high_risk)
+        
+    Returns:
+        마크다운 형식의 문자열
+    """
+    if not isinstance(criteria, list) or not criteria:
+        return ""
+    
+    # 각 AND 그룹을 괄호로 묶어서 처리
+    or_groups = []
+    
+    for and_group in criteria:
+        if not isinstance(and_group, list) or not and_group:
+            continue
+        
+        # 모든 조건 그룹을 괄호로 감싸기 (단일 조건 포함)
+        quoted_conditions = [f'"{condition}"' for condition in and_group]
+        and_conditions = " AND ".join(quoted_conditions)
+        or_groups.append(f"({and_conditions})")
+    
+    if not or_groups:
+        return ""
+    
+    # OR로 연결하여 최종 문자열 생성
+    criteria_text = " OR ".join(or_groups)
+    return f"- {criteria_text}\n"
+
+
 def cohort_to_markdown(cohort: Dict[str, Any]) -> str:
     """
     코호트 데이터를 마크다운 형식으로 변환합니다.
@@ -26,18 +61,22 @@ def cohort_to_markdown(cohort: Dict[str, Any]) -> str:
         if details:
             markdown += f"{details}\n\n"
         
+        # 새로운 중첩 배열 구조의 inclusion_criteria 처리
         inclusion_criteria = sub_cohort.get('inclusion_criteria', [])
         if inclusion_criteria:
             markdown += "### Inclusion Criteria\n"
-            for criterion in inclusion_criteria:
-                markdown += f"- {criterion}\n"
+            criteria_text = format_criteria_to_markdown(inclusion_criteria)
+            if criteria_text:
+                markdown += criteria_text
             markdown += "\n"
         
+        # 새로운 중첩 배열 구조의 exclusion_criteria 처리
         exclusion_criteria = sub_cohort.get('exclusion_criteria', [])
         if exclusion_criteria:
             markdown += "### Exclusion Criteria\n"
-            for criterion in exclusion_criteria:
-                markdown += f"- {criterion}\n"
+            criteria_text = format_criteria_to_markdown(exclusion_criteria)
+            if criteria_text:
+                markdown += criteria_text
             markdown += "\n"
         
         source_sentences = sub_cohort.get('source_sentences', [])

--- a/src/llm_source_to_kg/graph/cohort_graph/prompts/extract_cohort_prompt.txt
+++ b/src/llm_source_to_kg/graph/cohort_graph/prompts/extract_cohort_prompt.txt
@@ -17,28 +17,51 @@ Read the provided guideline. From it, define **3 to 5 high-level main cohort the
             "subject": "Sub-cohort title",
             "details": "Detailed sub-group use case"
           },
-          "inclusion_criteria": ["..."],
-          "exclusion_criteria": ["..."],
+          "inclusion_criteria": [
+            ["condition a", "condition b", ...],
+            ["condition c", ...],
+            "... additional condition groups as needed ..."
+          ],
+          "exclusion_criteria": [
+            ["condition a", "condition b", ...],
+            ["condition c", ...],
+            "... additional condition groups as needed ..."
+          ],
           "source_sentences": ["Original sentence from the guideline...", "..."]
         }
       ]
     }
   ]
 }
+```
+
+## Schema Description
+- **main_cohorts**: Array of main cohort objects representing broad clinical themes
+- **subject**: String title for the main cohort or sub-cohort
+- **details**: String with expanded description of the clinical theme or use case
+- **sub_cohorts**: Array of sub-cohort objects representing specific clinical scenarios
+- **description**: Object containing subject and details for each sub-cohort
+- **inclusion_criteria**: Array of arrays representing logical OR groups, where each inner array contains AND conditions
+- **exclusion_criteria**: Array of arrays with same logical structure as inclusion_criteria
+- **source_sentences**: Array of strings containing exact text from the original guideline
 
 ## Extraction Guidelines
-- Main cohorts should correspond to broad themes such as:
-- “Cardiovascular disease risk assessment”
-- “Statin-based lipid lowering”
-- “Secondary prevention for people with CVD”
+- Main cohorts should correspond to broad clinical themes derived from the specific guideline content
 - Sub-cohorts must contain:
-- At least one of: drug name, diagnosis, test with cutoff, procedure, or time logic
-- Explicit inclusion_criteria and source_sentences
-- Avoid listing general population statements unless they are clearly tied to a clinical recommendation.
-- Do not paraphrase source sentences.
-- Output only one JSON block.
+  - At least one of: drug name, diagnosis, test with cutoff, procedure, or time logic
+  - Explicit inclusion_criteria and exclusion_criteria with logical structure
+  - Direct source_sentences from the guideline
+- For criteria logical structure:
+  - Outer array represents OR relationships between condition groups
+  - Inner arrays represent AND relationships within each condition group
+  - Single conditions should be placed in their own inner array
+  - Each condition should be a clear, specific clinical criterion
+  - Number of condition groups should reflect the actual clinical logic in the guideline
+- Avoid listing general population statements unless they are clearly tied to a clinical recommendation
+- Do not paraphrase source sentences - use exact text from the guideline
+- Output only one JSON block
 
 ## Purpose
-This output supports downstream deep analysis nodes which will extract concept-relation triples (e.g., statin → for → QRISK ≥10%) and temporal constraints, for integration into a clinical knowledge graph.
+This output supports downstream deep analysis nodes which will extract concept-relation triples and temporal constraints, for integration into a clinical knowledge graph.
 
 Begin extraction now.


### PR DESCRIPTION
# 🔄 변경 사항
<!-- 주요 변경 사항을 설명해주세요 -->
- 프롬프트 스키마 수정
- 코호트 스키마 수정에 따른 스키마 검증 로직 수정
- 코호트 스키마 수정에 따른 마크다운 변환 로직 수정

## 작업 내용
<!-- 어떤 내용을 변경했는지 설명해주세요 -->
- 코호트 추출 criteria에 AND, OR 명시
## 관련 이슈
#11 

# 📝 체크리스트
<!-- PR 전 확인해야 할 사항들을 체크해주세요 -->
- [x] main 브랜치와 충돌 여부 확인
- [x] 테스트 충분히 했는지 확인

# 📌 추가 정보

## Criteria 형식

- criteria는 2차원 배열로 구성

```
[
  ["a", "b"],
  ["c"]
]
```
이면, (`"a"` AND `"b"`) OR (`"c"`)

- e.g.

``` 
"inclusion_criteria": [
  ["Diagnosis of proliferative diabetic retinopathy", "Diagnosis of diabetic macular oedema"],
  ["Received treatment"]
]
```

=> (`"Diagnosis of proliferative diabetic retinopathy"` AND `"Diagnosis of diabetic macular oedema"`) OR (`"Received treatment"`)


@rose2gyqls 검증으로 넘길 때 json보다 마크다운이 더 좋으면 추가로 수정할게요